### PR TITLE
Add test coverage and fix for key/child validation warnings

### DIFF
--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -47,6 +47,9 @@ class ReactComponentFactoryProxy implements Function {
 
   JsObject call(Map props, [dynamic children]) {
     List<dynamic> reactParams = [_generateExtendedJSProps(props, children)];
+    if (children is Iterable) {
+      children = new JsArray.from(children);
+    }
     reactParams.add(children);
     return reactComponentFactory.apply(reactParams);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,4 +9,4 @@ dependencies:
   browser: '>=0.9.0 <0.11.0'
   quiver: '>=0.18.2 < 0.19.0'
 dev_dependencies:
-  unittest: any
+  unittest: '^0.11.0'

--- a/test/child_key_warning_test.dart
+++ b/test/child_key_warning_test.dart
@@ -1,0 +1,123 @@
+import 'dart:html';
+import 'dart:js';
+
+import 'package:unittest/unittest.dart';
+import 'package:unittest/html_config.dart';
+
+import 'package:react/react.dart' as react;
+import 'package:react/react_client.dart';
+import 'package:react/react_test_utils.dart' as react_test_utils;
+
+
+void main() {
+  useHtmlConfiguration();
+  setClientConfiguration();
+
+  void render(JsObject reactElement) {
+    react_test_utils.renderIntoDocument(reactElement);
+  }
+
+  group('Key/children validation', () {
+    bool consoleWarnCalled;
+    var consoleWarnMessage;
+    JsFunction originalConsoleWarn;
+
+    setUp(() {
+      consoleWarnCalled = false;
+      consoleWarnMessage = null;
+
+      originalConsoleWarn = context['console']['warn'];
+      context['console']['warn'] = new JsFunction.withThis((self, message) {
+        consoleWarnCalled = true;
+        consoleWarnMessage = message;
+
+        originalConsoleWarn.apply([message], thisArg: self);
+      });
+    });
+
+    tearDown(() {
+      context['console']['warn'] = originalConsoleWarn;
+    });
+
+    group('warns when multiple children are passed as a list', () {
+      test('when rendering DOM components', () {
+        render(
+            react.div({}, [
+              react.span({}),
+              react.span({}),
+              react.span({})
+            ])
+        );
+
+        expect(consoleWarnCalled, isTrue, reason: 'should have outputted a warning');
+        expect(consoleWarnMessage, contains('Each child in an array or iterator should have a unique "key" prop.'));
+      });
+
+      test('when rendering custom Dart components', () {
+        render(
+            CustomComponent({}, [
+              react.span({}),
+              react.span({}),
+              react.span({})
+            ])
+        );
+
+        expect(consoleWarnCalled, isTrue, reason: 'should have outputted a warning');
+        expect(consoleWarnMessage, contains('Each child in an array or iterator should have a unique "key" prop.'));
+      });
+    });
+
+    group('does not warn when multiple children are passed as variadic args', () {
+      test('when rendering DOM components', () {
+        render(
+            react.div({},
+              react.span({}),
+              react.span({}),
+              react.span({})
+            )
+        );
+
+        expect(consoleWarnCalled, isFalse, reason: 'should not have outputted a warning');
+      });
+
+      test('when rendering custom Dart components', () {
+        render(
+            CustomComponent({},
+              react.span({}),
+              react.span({}),
+              react.span({})
+            )
+        );
+
+        expect(consoleWarnCalled, isFalse, reason: 'should not have outputted a warning');
+      });
+    });
+
+    group('does not warn when a single child is passed', () {
+      test('when rendering DOM components', () {
+        render(
+            react.div({},
+              react.span({})
+            )
+        );
+
+        expect(consoleWarnCalled, isFalse, reason: 'should not have outputted a warning');
+      });
+
+      test('when rendering custom Dart components', () {
+        render(
+            CustomComponent({},
+              react.span({})
+            )
+        );
+
+        expect(consoleWarnCalled, isFalse, reason: 'should not have outputted a warning');
+      });
+    });
+  });
+}
+
+Function CustomComponent = react.registerComponent(() => new _CustomComponent());
+class _CustomComponent extends react.Component {
+  render() => react.div({}, []);
+}

--- a/test/child_key_warning_test.html
+++ b/test/child_key_warning_test.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+    <meta charset="UTF-8">
+    <title></title>
+    <script src="packages/react/react_with_addons.js"></script>
+    <script type="application/dart" src="child_key_warning_test.dart"></script>
+    <script src="packages/browser/dart.js"></script>
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
- Added unit tests that validate `Each child in an array or iterator should have a unique "key" prop.` warnings are shown when expected.
- Fixed issue:
  - When `children` of type `List` are passed to React as a non-`JsArray`, React's internals only sees them as a `DartObject`, so it cannot validate them properly. It may also have other negative effects on how React handles `children` internally.
